### PR TITLE
fixing relative import path

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"./dhcp"
+	"github.com/cmatsuoka/dhcpcheck/dhcp"
 	"flag"
 	"fmt"
 	"os"


### PR DESCRIPTION
```
go get github.com/cmatsuoka/dhcpcheck
../../go/src/github.com/cmatsuoka/dhcpcheck/discover.go:4:2: local import "./dhcp" in non-local package
../../go/src/github.com/cmatsuoka/dhcpcheck/show.go:8:2: local import "./format" in non-local package
```