### PR TITLE
fixed relative import paths

### DIFF
--- a/discover.go
+++ b/discover.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"./dhcp"
 	"flag"
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/cmatsuoka/dhcpcheck/dhcp"
 )
 
 var Version = "0.1"

--- a/show.go
+++ b/show.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"./dhcp"
-	"./format"
+	"github.com/cmatsuoka/dhcpcheck/dhcp"
+	"github.com/cmatsuoka/dhcpcheck/format"
 	"github.com/cmatsuoka/dncomp"
 )
 

--- a/snoop.go
+++ b/snoop.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"./dhcp"
 	"flag"
 	"fmt"
 	"os"
+
+	"github.com/cmatsuoka/dhcpcheck/dhcp"
 )
 
 func cmdSnoop() {


### PR DESCRIPTION
Builds were not working without first doing a checkout.

```
../../go/src/github.com/cmatsuoka/dhcpcheck/discover.go:4:2: local import "./dhcp" in non-local package
../../go/src/github.com/cmatsuoka/dhcpcheck/show.go:8:2: local import "./format" in non-local package
```